### PR TITLE
Add accessibility support to proxy generation

### DIFF
--- a/src/Reflexor/Proxy.cs
+++ b/src/Reflexor/Proxy.cs
@@ -1,10 +1,12 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 
 namespace Reflexor;
 
 public readonly record struct Proxy(
     string Name,
     string? Namespace,
+    Accessibility Accessibility,
     string TargetType,
     string DisplayTargetType,
     bool IsStatic,

--- a/src/Reflexor/ProxyGenerator.cs
+++ b/src/Reflexor/ProxyGenerator.cs
@@ -46,6 +46,7 @@ public sealed class ProxyGenerator : IIncrementalGenerator
                         Namespace: targetType.ContainingNamespace.IsGlobalNamespace
                             ? null
                             : targetType.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
+                        Accessibility: targetType.DeclaredAccessibility,
                         TargetType: targetType.ToDisplayString(s_fullyQualifiedNullableFormat),
                         DisplayTargetType: targetType.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat),
                         IsStatic: targetType.IsStatic,

--- a/src/Reflexor/ProxyWriter.cs
+++ b/src/Reflexor/ProxyWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
 
 namespace Reflexor;
 
@@ -67,7 +68,19 @@ public static class ProxyWriter
 
         private void WriteProxyDeclaration(Proxy proxy)
         {
-            writer.Write("public ");
+            var accessibility = proxy.Accessibility switch
+            {
+                Accessibility.NotApplicable => string.Empty,
+                Accessibility.Private => "private",
+                Accessibility.ProtectedAndInternal => "private protected",
+                Accessibility.Protected => "protected",
+                Accessibility.Internal => "internal",
+                Accessibility.ProtectedOrInternal => "protected internal",
+                Accessibility.Public => "public",
+                _ => throw new InvalidOperationException($"Unknown accessibility: '{proxy.Accessibility}'")
+            };
+            writer.Write(accessibility);
+            writer.Write(" ");
 
             if (proxy.IsStatic)
             {


### PR DESCRIPTION
Proxy now includes an Accessibility property, set by ProxyGenerator from the target type. ProxyWriter uses this to emit the correct accessibility modifier in generated code.